### PR TITLE
Changes made to local_xmlsync and core_backup to support the switch f…

### DIFF
--- a/backup/externallib.php
+++ b/backup/externallib.php
@@ -263,6 +263,7 @@ class core_backup_external extends external_api {
                             'backupid' => new external_value(PARAM_ALPHANUM, 'Backup id'),
                             'restoreid' => new external_value(PARAM_ALPHANUM, 'Restore id'),
                             'operation' => new external_value(PARAM_ALPHANUM, 'Operation type'),
+                            'clone_creation_date' => new external_value(PARAM_INT, 'clone creation date'),
                         ), 'Copy data'
                     ), 'Copy data'
                 ),

--- a/backup/util/helper/copy_helper.class.php
+++ b/backup/util/helper/copy_helper.class.php
@@ -72,7 +72,7 @@ final class copy_helper {
      * @param \stdClass $copydata Course copy data from process_formdata
      * @return array $copyids The backup and restore controller ids
      */
-    public static function create_copy(\stdClass $copydata): array {
+    public static function create_copy(\stdClass $copydata, $clone_creation_date = true): array {
         global $USER;
         $copyids = [];
 
@@ -89,6 +89,7 @@ final class copy_helper {
             \backup::MODE_COPY, $USER->id, \backup::TARGET_NEW_COURSE, null,
             \backup::RELEASESESSION_NO, $copydata);
         $copyids['restoreid'] = $rc->get_restoreid();
+        $copyids['clone_creation_date'] = $clone_creation_date;
 
         $bc->set_status(\backup::STATUS_AWAITING);
         $bc->get_status();

--- a/local/xmlsync/classes/privacy/provider.php
+++ b/local/xmlsync/classes/privacy/provider.php
@@ -1,0 +1,48 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * XML enrol import task
+ *
+ * @package    local_xmlsync
+ * @author     David Thompson <david.thompson@catalyst.net.nz>
+ * @copyright  2021 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_xmlsync\privacy;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Privacy provider implementation for local_xmlsync.
+ *
+ * @copyright  2021 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class provider implements \core_privacy\local\metadata\null_provider {
+
+    /**
+     * Get the language string identifier with the component's language
+     * file to explain why this plugin stores no data.
+     *
+     * @return  string
+     */
+    public static function get_reason() : string {
+        return 'privacy:metadata';
+    }
+}
+

--- a/local/xmlsync/classes/util.php
+++ b/local/xmlsync/classes/util.php
@@ -26,7 +26,7 @@
 namespace local_xmlsync;
 
 use moodle_exception;
-
+require_once($CFG->dirroot . '/backup/util/helper/copy_helper.class.php');
 defined('MOODLE_INTERNAL') || die();
 
 class util {
@@ -160,8 +160,9 @@ class util {
                 // Cast to stdClass object.
                 $mdata = (object) $dummyform;
 
-                $backupcopy = new \core_backup\copy\copy($mdata);
-                $matchingrecord->copy_task_controllers = json_encode($backupcopy->create_copy(False));
+                $backupcopy = new \copy_helper();
+                $pdata = $backupcopy->process_formdata($mdata);
+                $matchingrecord->copy_task_controllers = json_encode($backupcopy->create_copy($pdata));
                 $DB->update_record('local_xmlsync_crsimport', $matchingrecord);
                 return True;
             }

--- a/local/xmlsync/lang/en/local_xmlsync.php
+++ b/local/xmlsync/lang/en/local_xmlsync.php
@@ -78,3 +78,4 @@ $string['error:unknownaction'] = 'Unknown action in import file: \'{$a}\'';
 
 $string['warning:timestampmatch'] = 'Timestamp exactly matches previously imported file. Importing skipped.';
 $string['warning:dryrun'] = 'Dry run: no table name specified.';
+$string['privacy:metadata'] = 'The xmlsync plugin does not store any personal data.';


### PR DESCRIPTION
Changes made to local_xmlsync and core_backup to support the switch from using deprecated copy.php to copy_helper class.

WR396437

modified:   backup/externallib.php
modified:   backup/util/helper/copy_helper.class.php
new file:   local/xmlsync/classes/privacy/provider.php
modified:   local/xmlsync/classes/util.php
modified:   local/xmlsync/lang/en/local_xmlsync.php


