### PR TITLE
Changes for depreciated function get_copy() in asynchronous_copy_task

### DIFF
--- a/lib/classes/task/asynchronous_copy_task.php
+++ b/lib/classes/task/asynchronous_copy_task.php
@@ -66,8 +66,9 @@ class asynchronous_copy_task extends adhoc_task {
             delete_course($restorerecord->itemid, false); // Clean up partially created destination course.
             return; // Return early as we can't continue.
         }
+        $rc = \restore_controller::load_controller($restoreid);  // Get the restore controller by restore id.
         $bc->set_progress(new \core\progress\db_updater($backuprecord->id, 'backup_controllers', 'progress'));
-        $copyinfo = $bc->get_copy();
+        $copyinfo = $rc->get_copy();
         $backupplan = $bc->get_plan();
 
         $keepuserdata = (bool)$copyinfo->userdata;


### PR DESCRIPTION
Hi,

This change will fix the error in  core\task\asynchronous_copy_task base_controller::get_copy().

Execute adhoc task: core\task\asynchronous_copy_task
... started 15:39:50. Current memory use 14.4MB.
Course copy: Processing asynchronous course copy for course id: 3127
... used 4 dbqueries
... used 0.024457216262817 seconds
Adhoc task failed: core\task\asynchronous_copy_task,Return value of base_controller::get_copy() must be an instance of stdClass, null returned
Backtrace:
* line 70 of /lib/classes/task/asynchronous_copy_task.php: call to base_controller->get_copy()
* line 341 of /lib/cronlib.php: call to core\task\asynchronous_copy_task->execute()
* line 198 of /lib/cronlib.php: call to cron_run_inner_adhoc_task()
* line 76 of /lib/cronlib.php: call to cron_run_adhoc_tasks()
* line 178 of /admin/cli/cron.php: call to cron_run()

Regards,
Sumaiya